### PR TITLE
Feature: CPTMATCHLBLROT now uses implied selection

### DIFF
--- a/src/CivilSurveySuite.CIVIL/Commands.cs
+++ b/src/CivilSurveySuite.CIVIL/Commands.cs
@@ -109,7 +109,7 @@ namespace CivilSurveySuite.CIVIL
             CogoPointUtils.DescriptionFormatToUpper();
         }
 
-        [CommandMethod("WMS", "CSSCptMatchLblRot", CommandFlags.Modal)]
+        [CommandMethod("WMS", "CSSCptMatchLblRot", CommandFlags.Modal | CommandFlags.UsePickSet)]
         public static void CptMatchLblRot()
         {
             CogoPointUtils.LabelRotateMatch();


### PR DESCRIPTION
If CogoPoints are already selected when running the command, they are used as the selection automatically.